### PR TITLE
Added French translation

### DIFF
--- a/Common/src/main/resources/assets/worldplaytime/lang/fr_fr.json
+++ b/Common/src/main/resources/assets/worldplaytime/lang/fr_fr.json
@@ -1,0 +1,22 @@
+{
+  "worldplaytime.format": "%sh",
+  "worldplaytime.config.header": "Paramètres de World Play Time",
+  "worldplaytime.config.category.general": "Général",
+  "worldplaytime.config.category.world_entry": "Paramètres monde",
+  "worldplaytime.config.category.server_entry": "Paramètres serveur",
+
+  "worldplaytime.config.showServerPlayTime": "Afficher le temps de jeu sur serveur",
+  "worldplaytime.config.serverPlayTimePosition": "Position du temps de jeu sur serveur",
+  "worldplaytime.config.serverPlayTimePosition.after_name": "Après le nom",
+  "worldplaytime.config.serverPlayTimePosition.behind_count": "Derrière le compteur",
+  "worldplaytime.config.serverPlayTimePosition.left": "Gauche",
+  "worldplaytime.config.serverPlayTimePosition.right": "Droite",
+  "worldplaytime.config.serverPlayTimeColor": "Couleur du temps de jeu sur serveur",
+  
+  "worldplaytime.config.showWorldPlayTime": "Afficher le temps de jeu des mondes",
+  "worldplaytime.config.worldPlayTimePosition": "Position du temps de jeu des mondes",
+  "worldplaytime.config.worldPlayTimePosition.top_right": "En haut à droite",
+  "worldplaytime.config.worldPlayTimePosition.left": "Gauche",
+  "worldplaytime.config.worldPlayTimePosition.right": "Droite",
+  "worldplaytime.config.worldPlayTimeColor": "Couleur du temps de jeu des mondes"
+}


### PR DESCRIPTION
I've added `fr_fr.json` file for french translation, I've used longer expression in french translation than english one which is expected. I've kept the "do not translate the mod name" convention in the `worldplaytime.config.header`.

On 1920x1080 at GUI scale x4 the texts correctly place but in little windows does not and exceed in the `worldplaytime.config.serverPlayTimeColor` and `worldplaytime.config.worldPlayTimeColor`, do you want me to shorten french values ?

Here is the comparison between the full size and the little windows.
<img width="1920" height="1032" alt="full size" src="https://github.com/user-attachments/assets/08ae579c-f393-42b9-85a5-91df8885b03b" />

<img width="856" height="512" alt="little windows" src="https://github.com/user-attachments/assets/72d425a4-e0b0-42c6-ab1e-a4c3331f6b7d" />

To avoid overlapping on really little resolutions I can edit for example :
"Couleur du temps de jeu sur serveur" for "Couleur temps de jeu sur serveur", it's less verbose but still clear enough.
I don't know what you prefer ? More verbale approach but overlapping or the opposite ?